### PR TITLE
backingStoreType was added to OSX 10.10

### DIFF
--- a/Octosaver/OctosaverView.m
+++ b/Octosaver/OctosaverView.m
@@ -123,6 +123,10 @@
     return nil;
 }
 
++ (NSBackingStoreType)backingStoreType {
+    return NSBackingStoreBuffered;
+}
+
 #pragma mrk - Private
 - (void) refreshOctocat
 {


### PR DESCRIPTION
This keeps some machines running OSX 10.10 from showing flickering by specifically using a buffered backingStoreType
